### PR TITLE
Use all groups that a user is part of when calling a user scoped script

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -72,7 +72,7 @@ func TestRouter(t *testing.T) {
 			configuration{DefaultToken: "test", Scripts: []script{{ID: parseUUIDOrPanic("b9f71a96-0d23-11ee-860e-ff55b106c448"), Path: "./scripts/failure.sh"}}},
 			"test",
 			http.StatusInternalServerError,
-			"ko\n\nexit status 1\n",
+			"ko\n\n\nexit status 1\n",
 		},
 		{
 			"When the hook endpoint is called with a correct script that uses its own token using the default token, it should return 401",


### PR DESCRIPTION
this way if a user is part of the Docker group, it can actually access the docker socket
