### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ We use a yaml configuration file and it's read by default from `./config.yaml`
 ```yaml
 default_token: KXjk9waX9fqRLQ4t8sQf5IK94e2u1CXr8X4MscDc # Token used for all scripts that don't specify one
 
+environment:
+  - key: TITLE
+    value: Mr.
+
 scripts:
   - id: 5e5adb92-0d04-11ee-97cf-4b6c30e50f6a # ID of the script (a UUID)
     path: ./scripts/success.sh # Path to the script
@@ -37,6 +41,12 @@ scripts:
   - id: 47878e38-a700-11ee-bc6d-f3d25921fcde
     inline: | # Use an inline script instead of a path to a script
       echo "Hello, world!"
+  - id: 34ca006a-ece6-11ee-a395-17c174ecf4c7
+    inline: |
+      echo "Hello, $TITLE $NAME!"
+    environment: # Environment variables to pass to the script
+      - key: NAME
+        value: Frodo
 ```
 
 ## Calling the service

--- a/config.go
+++ b/config.go
@@ -8,13 +8,19 @@ import (
 )
 
 type script struct {
-	ID         uuid.UUID `yaml:"id"`
-	Path       string    `yaml:"path,omitempty"`
-	Inline     string    `yaml:"inline,omitempty"`
-	Token      string    `yaml:"token,omitempty"`
-	Concurrent bool      `yaml:"concurrent"`
-	Shell      string    `yaml:"shell"`
-	User       string    `yaml:"user"`
+	ID          uuid.UUID     `yaml:"id"`
+	Path        string        `yaml:"path,omitempty"`
+	Inline      string        `yaml:"inline,omitempty"`
+	Token       string        `yaml:"token,omitempty"`
+	Concurrent  bool          `yaml:"concurrent"`
+	Shell       string        `yaml:"shell"`
+	User        string        `yaml:"user"`
+	Environment []environment `yaml:"environment"`
+}
+
+type environment struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 func (s script) isValid() bool {
@@ -22,8 +28,9 @@ func (s script) isValid() bool {
 }
 
 type configuration struct {
-	DefaultToken string   `yaml:"default_token"`
-	Scripts      []script `yaml:"scripts"`
+	DefaultToken string        `yaml:"default_token"`
+	Scripts      []script      `yaml:"scripts"`
+	Environment  []environment `yaml:"environment"`
 }
 
 func getConfig(configFile string) (configuration, error) {

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,9 @@
 default_token: KXjk9waX9fqRLQ4t8sQf5IK94e2u1CXr8X4MscDc
 
+environment:
+  - key: TITLE
+    value: Mr.
+
 scripts:
   - id: 5e5adb92-0d04-11ee-97cf-4b6c30e50f6a
     path: ./scripts/success.sh
@@ -10,3 +14,9 @@ scripts:
   - id: 47878e38-a700-11ee-bc6d-f3d25921fcde
     inline: |
       echo "Hello, world!"
+  - id: 34ca006a-ece6-11ee-a395-17c174ecf4c7
+    inline: |
+      echo "Hello, $TITLE $NAME!"
+    environment:
+      - key: NAME
+        value: Frodo

--- a/config_test.go
+++ b/config_test.go
@@ -13,13 +13,14 @@ func TestConfigurationLoadsCorrectly(t *testing.T) {
 	scriptUUID, err := uuid.Parse("5e5adb92-0d04-11ee-97cf-4b6c30e50f6a")
 	require.NoError(t, err)
 	assert.Equal(t, "KXjk9waX9fqRLQ4t8sQf5IK94e2u1CXr8X4MscDc", c.DefaultToken)
-	assert.Len(t, c.Scripts, 3)
+	assert.Len(t, c.Scripts, 4)
 	assert.Equal(t, scriptUUID, c.Scripts[0].ID)
 	assert.Equal(t, "./scripts/success.sh", c.Scripts[0].Path)
 	assert.False(t, c.Scripts[0].Concurrent)
 	assert.True(t, c.Scripts[1].Concurrent)
 	assert.Equal(t, "YT9U08gqQ8yxa0Sk3PnDk6jpWu31bCyqa5SRQVFV8", c.Scripts[1].Token)
 	assert.Equal(t, "echo \"Hello, world!\"\n", c.Scripts[2].Inline)
+	assert.Equal(t, []environment{{Key: "NAME", Value: "Frodo"}}, c.Scripts[3].Environment)
 }
 
 func TestConfigurationFailsOnInvalidScript(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -42,7 +42,7 @@ func executionHandler(c configuration, locks map[uuid.UUID]*sync.Mutex) func(w h
 			defer locks[scriptToRun.ID].Unlock()
 		}
 
-		output, err := executeScript(scriptToRun)
+		output, err := executeScript(scriptToRun, c.Environment)
 		if err != nil {
 			reportError(err, w)
 			return

--- a/router_test.go
+++ b/router_test.go
@@ -106,6 +106,30 @@ func TestRouter(t *testing.T) {
 			http.StatusOK,
 			"inline\n",
 		},
+		{
+			"When an environment variable is specified then it should be passed to the script",
+			"/hook?script=47878e38-a700-11ee-bc6d-f3d25921fcde",
+			configuration{DefaultToken: "test", Scripts: []script{{ID: parseUUIDOrPanic("47878e38-a700-11ee-bc6d-f3d25921fcde"), Inline: "echo $NAME", Token: "nonya", Environment: []environment{{Key: "NAME", Value: "Gandalf"}}}}},
+			"nonya",
+			http.StatusOK,
+			"Gandalf\n",
+		},
+		{
+			"When a global environment variable is specified then it should be passed to the script",
+			"/hook?script=47878e38-a700-11ee-bc6d-f3d25921fcde",
+			configuration{DefaultToken: "test", Environment: []environment{{Key: "NAME", Value: "Gandalf"}}, Scripts: []script{{ID: parseUUIDOrPanic("47878e38-a700-11ee-bc6d-f3d25921fcde"), Inline: "echo $NAME", Token: "nonya"}}},
+			"nonya",
+			http.StatusOK,
+			"Gandalf\n",
+		},
+		{
+			"When the same global environment variable and script one are is specified then the script should use the script scoped one",
+			"/hook?script=47878e38-a700-11ee-bc6d-f3d25921fcde",
+			configuration{DefaultToken: "test", Environment: []environment{{Key: "NAME", Value: "Gandalf"}}, Scripts: []script{{ID: parseUUIDOrPanic("47878e38-a700-11ee-bc6d-f3d25921fcde"), Inline: "echo $NAME", Token: "nonya", Environment: []environment{{Key: "NAME", Value: "frodo"}}}}},
+			"nonya",
+			http.StatusOK,
+			"frodo\n",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This will allow us to set environment variables both globally and script scoped

```yaml
default_token: KXjk9waX9fqRLQ4t8sQf5IK94e2u1CXr8X4MscDc # Token used for all scripts that don't specify one

environment:
  - key: TITLE
    value: Mr.

scripts:
  - id: 34ca006a-ece6-11ee-a395-17c174ecf4c7
    inline: |
      echo "Hello, $TITLE $NAME!"
    environment: # Environment variables to pass to the script
      - key: NAME
        value: Frodo
```

Calling this script should result in "Hello, Mr. Frodo!"