### PR TITLE
Add steps to build and publish docker images with different bases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,6 +19,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,3 +57,119 @@ nfpms:
         dst: /etc/systemd/system/shellhook.service
         file_info:
           mode: 0600
+
+dockers:
+  - id: shellhook-debian-amd64
+    dockerfile: debian.Dockerfile
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:debian-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:debian-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:debian-v{{ .Major }}.{{ .Minor }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+
+  - id: shellhook-debian-arm64
+    dockerfile: debian.Dockerfile
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:debian-latest-arm64"
+      - "ghcr.io/jadolg/shellhook:debian-{{ .Tag }}-arm64"
+      - "ghcr.io/jadolg/shellhook:debian-v{{ .Major }}.{{ .Minor }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+
+  - id: shellhook-ubuntu-amd64
+    dockerfile: ubuntu.Dockerfile
+    use: buildx
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:ubuntu-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-v{{ .Major }}.{{ .Minor }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+
+  - id: shellhook-ubuntu-arm64
+    dockerfile: ubuntu.Dockerfile
+    goarch: arm64
+    use: buildx
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:ubuntu-latest-arm64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-{{ .Tag }}-arm64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-v{{ .Major }}.{{ .Minor }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+
+  - id: shellhook-alpine-amd64
+    dockerfile: alpine.Dockerfile
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:alpine-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:alpine-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:alpine-v{{ .Major }}.{{ .Minor }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+
+  - id: shellhook-alpine-arm64
+    dockerfile: alpine.Dockerfile
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:alpine-latest-arm64"
+      - "ghcr.io/jadolg/shellhook:alpine-{{ .Tag }}-arm64"
+      - "ghcr.io/jadolg/shellhook:alpine-v{{ .Major }}.{{ .Minor }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/jadolg/shellhook:debian-latest"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:debian-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:debian-latest-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:debian-{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:debian-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:debian-{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:debian-v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:debian-v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/jadolg/shellhook:debian-v{{ .Major }}.{{ .Minor }}-arm64"
+        
+  - name_template: "ghcr.io/jadolg/shellhook:ubuntu-latest"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:ubuntu-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-latest-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:ubuntu-{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:ubuntu-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:ubuntu-v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:ubuntu-v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/jadolg/shellhook:ubuntu-v{{ .Major }}.{{ .Minor }}-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:alpine-latest"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:alpine-latest-amd64"
+      - "ghcr.io/jadolg/shellhook:alpine-latest-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:alpine-{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:alpine-{{ .Tag }}-amd64"
+      - "ghcr.io/jadolg/shellhook:alpine-{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/jadolg/shellhook:alpine-v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/jadolg/shellhook:alpine-v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/jadolg/shellhook:alpine-v{{ .Major }}.{{ .Minor }}-arm64"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+COPY shellhook /usr/bin/shellhook
+CMD ["shellhook"]

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:12
+COPY shellhook /usr/bin/shellhook
+CMD ["shellhook"]

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+COPY shellhook /usr/bin/shellhook
+CMD ["shellhook"]


### PR DESCRIPTION
Supported systems are ubuntu, debian, and alpine both amd64 and arm64 architectures.