### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module shellhook
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.2**.

### Changes
- go.mod: go 1.25.0 → go 1.26.2

_Automated PR by update-go-version.sh_